### PR TITLE
authentication_bloc updated

### DIFF
--- a/pizza_app/lib/blocs/authentication_bloc/authentication_bloc.dart
+++ b/pizza_app/lib/blocs/authentication_bloc/authentication_bloc.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:user_repository/user_repository.dart';
+
+part 'authentication_event.dart';
+part 'authentication_state.dart';
+
+class AuthenticationBloc extends Bloc<AuthenticationEvent, AuthenticationState> {
+  final UserRepository userRepository;
+  late final StreamSubscription<MyUser?> _userSubscription;
+
+  AuthenticationBloc({
+    required this.userRepository
+  }) : super(const AuthenticationState.unknown()) {
+    _userSubscription = userRepository.user.listen((user) {
+      add(AuthenticationUserChanged(user));
+    });
+
+    on<AuthenticationUserChanged>((event, emit) {
+      if(event.user != MyUser.empty) {
+        emit(AuthenticationState.authenticated(event.user!));
+      } else {
+        emit(const AuthenticationState.unauthenticated());
+      }
+    });
+  }
+
+  @override
+  Future<void> close() {
+    _userSubscription.cancel();
+    return super.close();
+  }
+}

--- a/pizza_app/lib/blocs/authentication_bloc/authentication_event.dart
+++ b/pizza_app/lib/blocs/authentication_bloc/authentication_event.dart
@@ -1,0 +1,14 @@
+part of 'authentication_bloc.dart';
+
+sealed class AuthenticationEvent extends Equatable {
+  const AuthenticationEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+class AuthenticationUserChanged extends AuthenticationEvent {
+  final MyUser? user;
+
+  const AuthenticationUserChanged(this.user);
+}

--- a/pizza_app/lib/blocs/authentication_bloc/authentication_state.dart
+++ b/pizza_app/lib/blocs/authentication_bloc/authentication_state.dart
@@ -1,0 +1,24 @@
+part of 'authentication_bloc.dart';
+
+enum AuthenticationStatus { authenticated, unauthenticated, unknown }
+
+class AuthenticationState extends Equatable {
+  const AuthenticationState._({
+    this.status = AuthenticationStatus.unknown,
+    this.user
+  });
+
+  final AuthenticationStatus status;
+  final MyUser? user;
+
+  const AuthenticationState.unknown() : this._();
+
+  const AuthenticationState.authenticated(MyUser myUser) : 
+    this._(status: AuthenticationStatus.authenticated, user: myUser);
+
+  const AuthenticationState.unauthenticated() :
+    this._(status: AuthenticationStatus.unauthenticated);
+
+  @override
+  List<Object?> get props => [status, user];
+}


### PR DESCRIPTION
This pull request introduces a new `AuthenticationBloc` to manage authentication state in the application. The changes include the creation of the bloc itself, along with the corresponding events and states.

New `AuthenticationBloc` implementation:

* [`pizza_app/lib/blocs/authentication_bloc/authentication_bloc.dart`](diffhunk://#diff-63f11ffb4b6fe8a45560faef1e3953cd70681787330209d89fdaee2742404792R1-R35): Added the `AuthenticationBloc` class to manage authentication state, including handling user changes and emitting appropriate states.

Supporting event and state classes:

* [`pizza_app/lib/blocs/authentication_bloc/authentication_event.dart`](diffhunk://#diff-6d49a4a0cb196e5ae4fb93c1a94b80dbcdef5b972ed1e0506113303896d83f82R1-R14): Created the `AuthenticationEvent` class and its subclass `AuthenticationUserChanged` to represent changes in the user state.
* [`pizza_app/lib/blocs/authentication_bloc/authentication_state.dart`](diffhunk://#diff-609867f9b8b7e1916b3cfc264849cfbc1e0c1af57ee5fa12a5648cca4d9510a5R1-R24): Defined the `AuthenticationState` class with different authentication statuses and constructors for authenticated, unauthenticated, and unknown states.