### PR TITLE
App view created

### DIFF
--- a/pizza_app/lib/app_view.dart
+++ b/pizza_app/lib/app_view.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pizza_app/blocs/authentication_bloc/authentication_bloc.dart';
+import 'package:pizza_app/screens/auth/blocs/sing_in_bloc/sign_in_bloc.dart';
+import 'package:pizza_app/screens/home/blocs/get_pizza_bloc/get_pizza_bloc.dart';
+import 'package:pizza_repository/pizza_repository.dart';
+
+import 'screens/auth/views/welcome_screen.dart';
+import 'screens/home/views/home_screen.dart';
+
+class MyAppView extends StatelessWidget {
+  const MyAppView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+        title: 'Pizza Delivery',
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(colorScheme: ColorScheme.light(background: Colors.grey.shade200, onBackground: Colors.black, primary: Colors.blue, onPrimary: Colors.white)),
+        home: BlocBuilder<AuthenticationBloc, AuthenticationState>(
+          builder: ((context, state) {
+            if (state.status == AuthenticationStatus.authenticated) {
+              return MultiBlocProvider(
+                providers: [
+                  BlocProvider(
+                    create: (context) => SignInBloc(context.read<AuthenticationBloc>().userRepository),
+                  ),
+                  BlocProvider(
+                    create: (context) => GetPizzaBloc(
+                      FirebasePizzaRepo()
+                    )..add(GetPizza()),
+                  ),
+                ],
+                child: const HomeScreen(),
+              );
+            } else {
+              return const WelcomeScreen();
+            }
+          }),
+        ));
+  }
+}


### PR DESCRIPTION
This pull request includes significant changes to the `pizza_app/lib/app_view.dart` file to set up the main application view for the Pizza Delivery app. The changes primarily involve the setup of the `MyAppView` class and the integration of various BLoC components.

Key changes include:

### Setup of Main Application View:

* Added the `MyAppView` class which extends `StatelessWidget` to serve as the main entry point of the app.
* Configured the `MaterialApp` widget with a title, theme, and home screen based on the authentication status.

### Integration of BLoC Components:

* Integrated `AuthenticationBloc` to manage authentication state and determine which screen to display (`HomeScreen` or `WelcomeScreen`).
* Added `SignInBloc` to handle sign-in operations within the app.
* Added `GetPizzaBloc` to manage the state and events related to fetching pizza data from `FirebasePizzaRepo`.